### PR TITLE
Add HandlerService

### DIFF
--- a/lib/toot.rb
+++ b/lib/toot.rb
@@ -5,6 +5,7 @@ require 'sidekiq'
 require 'toot/config'
 require 'toot/publishes_event'
 require 'toot/calls_event_callback'
+require 'toot/handler_service'
 require 'toot/source'
 require 'toot/subscription'
 

--- a/lib/toot/handler_service.rb
+++ b/lib/toot/handler_service.rb
@@ -1,0 +1,28 @@
+require 'rack'
+
+module Toot
+  class HandlerService
+
+    def call(env)
+      request = Rack::Request.new(env)
+      response = Rack::Response.new
+      payload = JSON.parse(request.body.read)
+
+      subscriptions = Toot.config.subscriptions.select { |s|
+        s.channel == request["channel_name"] }
+
+      subscriptions.each do |subscription|
+        subscription.handler.perform_async(payload)
+      end
+
+      response["X-Toot-Unsubscribe"] = "True" if subscriptions.size == 0
+
+      response.finish
+    end
+
+    def self.call(env)
+      new.call(env)
+    end
+
+  end
+end

--- a/spec/toot/handler_service_spec.rb
+++ b/spec/toot/handler_service_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe Toot::HandlerService do
+  let(:env) {
+    {
+      "REQUEST_METHOD" => "POST",
+      "QUERY_STRING" => "channel_name=test.channel",
+      "rack.input" => StringIO.new('{"payload":123}'),
+    }
+  }
+
+  context "with an event channel with a subscription" do
+    let(:handler) { spy(:handler) }
+    before do
+      Toot.config.source :test, subscription_url: "", channel_prefix: "test."
+      Toot.config.subscribe :test, 'channel', handler
+    end
+
+    it "enqueues the handler with the provided payload" do
+      response = Rack::MockResponse.new(*described_class.call(env))
+      expect(handler).to have_received(:perform_async).with({ "payload" => 123 })
+      expect(response.status).to eq(200)
+    end
+
+    it "enqueues multiple handlers when multiple have been defined" do
+      other_handler = spy(:other_handler)
+      Toot.config.subscribe :test, 'channel', other_handler
+      described_class.call(env)
+      expect(handler).to have_received(:perform_async)
+      expect(other_handler).to have_received(:perform_async)
+    end
+
+    it "does not include the X-Toot-Unsubscribe header" do
+      response = Rack::MockResponse.new(*described_class.call(env))
+      expect(response.headers.keys).to_not include("X-Toot-Unsubscribe")
+    end
+  end
+
+  context "with an event channel with no subscription" do
+    it "does not call another channel" do
+      handler = spy(:handler)
+      Toot.config.source :test, subscription_url: "", channel_prefix: "test."
+      Toot.config.subscribe :test, 'channel2', handler
+      described_class.call(env)
+      expect(handler).to_not have_received(:perform_async)
+    end
+
+    it "includes the X-Toot-Unsubscribe header" do
+      response = Rack::MockResponse.new(*described_class.call(env))
+      expect(response.status).to eq(200)
+      expect(response.headers.keys).to include("X-Toot-Unsubscribe")
+    end
+  end
+
+end

--- a/toot.gemspec
+++ b/toot.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sidekiq", ">=2"
+  spec.add_dependency "rack", ">=1"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This is a simple Rack app that processes an incoming event and
dispatches the appropriate event handlers based on registered
subscriptions.
