### PR TITLE
Add SubscriptionsService

### DIFF
--- a/lib/toot.rb
+++ b/lib/toot.rb
@@ -8,6 +8,7 @@ require 'toot/calls_event_callback'
 require 'toot/handler_service'
 require 'toot/source'
 require 'toot/subscription'
+require 'toot/subscriptions_service'
 
 module Toot
 

--- a/lib/toot/subscriptions_service.rb
+++ b/lib/toot/subscriptions_service.rb
@@ -1,0 +1,31 @@
+module Toot
+  class SubscriptionsService
+
+    def call(env)
+      request = Rack::Request.new(env)
+      response = Rack::Response.new
+      json = parse_body_json(request)
+
+      if request["channel_name"] && json["callback_url"]
+        Toot.redis do |r|
+          r.sadd request["channel_name"], json["callback_url"]
+        end
+      else
+        response.status = 422
+      end
+
+      response.finish
+    end
+
+    def self.call(env)
+      new.call(env)
+    end
+
+    private def parse_body_json(request)
+      JSON.parse(request.body.read)
+    rescue JSON::ParserError
+      {}
+    end
+
+  end
+end

--- a/spec/toot/subscriptions_service_spec.rb
+++ b/spec/toot/subscriptions_service_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe Toot::SubscriptionsService do
+  let(:connection) { instance_spy(Redis) }
+  let(:env) {
+    {
+      "REQUEST_METHOD" => "POST",
+      "QUERY_STRING" => "channel_name=test.channel",
+      "rack.input" => StringIO.new('{"callback_url":"http://example.com/callback"}'),
+    }
+  }
+
+  before do
+    allow(Toot).to receive(:redis) do |&blk|
+      blk.call(connection)
+    end
+  end
+
+  it "adds the given callback_url to the channel's set in Redis" do
+    response = Rack::MockResponse.new(*described_class.call(env))
+    expect(connection).to have_received(:sadd).with("test.channel", "http://example.com/callback")
+    expect(response.status).to eq(200)
+  end
+
+  it "does nothing and return 422 if channel_name isn't set" do
+    env.delete("QUERY_STRING")
+    response = Rack::MockResponse.new(*described_class.call(env))
+    expect(connection).to_not have_received(:sadd)
+    expect(response.status).to eq(422)
+  end
+
+  it "does nothing and returns 422 if callback_url isn't set" do
+    env["rack.input"] = StringIO.new('')
+    response = Rack::MockResponse.new(*described_class.call(env))
+    expect(connection).to_not have_received(:sadd)
+    expect(response.status).to eq(422)
+  end
+
+end


### PR DESCRIPTION
This handles requests to subscribe to a new channel. The callback_url is
stored in Redis and is read by the PublishesEvent service in order to
send publishings
