### PR TITLE
Add Event object with metadata

### DIFF
--- a/lib/toot.rb
+++ b/lib/toot.rb
@@ -3,6 +3,7 @@ require 'toot/version'
 require 'sidekiq'
 
 require 'toot/config'
+require 'toot/event'
 require 'toot/source'
 require 'toot/subscription'
 
@@ -32,7 +33,10 @@ module Toot
   end
 
   def self.publish(channel_name, payload, prefix: config.channel_prefix)
-    PublishesEvent.perform_async([prefix, channel_name].join, payload)
+    Event.new(
+      channel: [prefix, channel_name].join,
+      payload: payload
+    ).publish
   end
 
   def self.redis(connection=config.redis_connection, &block)

--- a/lib/toot/calls_event_callback.rb
+++ b/lib/toot/calls_event_callback.rb
@@ -4,10 +4,10 @@ module Toot
   class CallsEventCallback
     include Sidekiq::Worker
 
-    def perform(callback_url, payload)
+    def perform(callback_url, event_data)
       uri = URI(callback_url)
       request = Net::HTTP::Post.new(uri)
-      request.body = payload.to_json
+      request.body = event_data.to_json
       request.content_type = "application/json"
 
       response = Net::HTTP.start(uri.hostname, uri.port) do |http|

--- a/lib/toot/event.rb
+++ b/lib/toot/event.rb
@@ -1,0 +1,38 @@
+require 'securerandom'
+
+module Toot
+  class Event
+
+    attr_accessor :id, :timestamp, :payload, :channel
+
+    DEFAULTS = -> {
+      {
+        id: SecureRandom.uuid,
+        timestamp: Time.now,
+        payload: {},
+      }
+    }
+
+    def initialize(args={})
+      args = DEFAULTS.().merge(args.symbolize_keys)
+      @id = args[:id]
+      @timestamp = args[:timestamp]
+      @payload = args[:payload]
+      @channel = args[:channel]
+    end
+
+    def publish
+      PublishesEvent.perform_async(to_h)
+      self
+    end
+
+    def to_h
+      {
+        id: id,
+        timestamp: timestamp,
+        payload: payload,
+        channel: channel,
+      }
+    end
+  end
+end

--- a/lib/toot/handler_service.rb
+++ b/lib/toot/handler_service.rb
@@ -6,13 +6,13 @@ module Toot
     def call(env)
       request = Rack::Request.new(env)
       response = Rack::Response.new
-      payload = JSON.parse(request.body.read)
+      event_data = JSON.parse(request.body.read)
 
       subscriptions = Toot.config.subscriptions.select { |s|
         s.channel == request["channel_name"] }
 
       subscriptions.each do |subscription|
-        subscription.handler.perform_async(payload)
+        subscription.handler.perform_async(event_data)
       end
 
       response["X-Toot-Unsubscribe"] = "True" if subscriptions.size == 0

--- a/lib/toot/publishes_event.rb
+++ b/lib/toot/publishes_event.rb
@@ -2,9 +2,10 @@ module Toot
   class PublishesEvent
     include Sidekiq::Worker
 
-    def perform(channel_name, payload)
-      channel_callback_urls(channel_name)
-        .map { |callback| CallsEventCallback.perform_async(callback, payload) }
+    def perform(event_data)
+      event = Event.new(event_data)
+      channel_callback_urls(event.channel)
+        .map { |callback| CallsEventCallback.perform_async(callback, event_data) }
     end
 
     private

--- a/spec/toot/calls_event_callback_spec.rb
+++ b/spec/toot/calls_event_callback_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Toot::CallsEventCallback do
     WebMock.enable!
   end
 
-  it "does a POST to the callback with the payload as a JSON encoded body" do
+  it "does a POST to the callback with the event_data as a JSON encoded body" do
     stub_request(:post, "http://example.com/").and_return(status: 200)
-    described_class.new.perform("http://example.com/", { payload: 123 })
+    described_class.new.perform("http://example.com/", { data: 123 })
     expect(WebMock).to have_requested(:post, "http://example.com/")
-      .with(body: '{"payload":123}')
+      .with(body: '{"data":123}')
       .with(headers: { "Content-Type" => "application/json" })
   end
 

--- a/spec/toot/event_spec.rb
+++ b/spec/toot/event_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+RSpec.describe Toot::Event do
+
+  describe "#initialize with no args" do
+    it "sets timestamp to now" do
+      obj = described_class.new
+      expect(obj.timestamp).to be_within(1).of(Time.now)
+    end
+
+    it "sets payload to empty object" do
+      obj = described_class.new
+      expect(obj.payload).to eq({})
+    end
+
+    it "generates a unique id" do
+      obj = described_class.new
+      expect(obj.id).to match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/)
+      expect(described_class.new.id).to_not eq(described_class.new.id)
+    end
+  end
+
+  describe "#initialize with hash" do
+    it "sets timestamp to :timestamp" do
+      time = Time.new(2020, 10, 20, 00, 00, 00)
+      obj = described_class.new(timestamp: time)
+      expect(obj.timestamp).to eq(time)
+    end
+
+    it "sets payload to :payload" do
+      obj = described_class.new(payload: { data: 1 })
+      expect(obj.payload).to eq({ data: 1 })
+    end
+
+    it "sets channel to :channel" do
+      obj = described_class.new(channel: "foo")
+      expect(obj.channel).to eq("foo")
+    end
+
+    it "sets id to :id" do
+      obj = described_class.new(id: "foo")
+      expect(obj.id).to eq("foo")
+    end
+
+    it "allows string keys" do
+      obj = described_class.new("id" => "foo", :payload => { "data" => 1 })
+      expect(obj.id).to eq("foo")
+      expect(obj.payload).to eq({ "data" => 1 })
+    end
+  end
+
+  describe "#publish" do
+    subject(:event) { described_class.new }
+
+    it "calls PublishesEvent with encoded self" do
+      expect(Toot::PublishesEvent).to receive(:perform_async).with(event.to_h)
+      event.publish
+    end
+
+    it "returns self" do
+      expect(event.publish).to eq(event)
+    end
+  end
+
+  describe "#to_h" do
+    subject(:event) { described_class.new }
+
+    it "includes :id in hash" do
+      expect(event.to_h[:id]).to eq(event.id)
+    end
+
+    it "includes :timestamp in hash" do
+      expect(event.to_h[:timestamp]).to eq(event.timestamp)
+    end
+
+    it "includes :payload in hash" do
+      expect(event.to_h[:payload]).to eq(event.payload)
+    end
+
+    it "includes :channel in hash" do
+      event.channel = "foo"
+      expect(event.to_h[:channel]).to eq(event.channel)
+    end
+
+  end
+
+end

--- a/spec/toot/handler_service_spec.rb
+++ b/spec/toot/handler_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Toot::HandlerService do
     {
       "REQUEST_METHOD" => "POST",
       "QUERY_STRING" => "channel_name=test.channel",
-      "rack.input" => StringIO.new('{"payload":123}'),
+      "rack.input" => StringIO.new('{"event_data":123}'),
     }
   }
 
@@ -16,9 +16,9 @@ RSpec.describe Toot::HandlerService do
       Toot.config.subscribe :test, 'channel', handler
     end
 
-    it "enqueues the handler with the provided payload" do
+    it "enqueues the handler with the provided event_data" do
       response = Rack::MockResponse.new(*described_class.call(env))
-      expect(handler).to have_received(:perform_async).with({ "payload" => 123 })
+      expect(handler).to have_received(:perform_async).with({ "event_data" => 123 })
       expect(response.status).to eq(200)
     end
 

--- a/spec/toot/publishes_event_spec.rb
+++ b/spec/toot/publishes_event_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe Toot::PublishesEvent do
     end
 
     it "queries Toot.redis for set members enqueueing a CallsEventCallback for each item" do
+      event_data = Toot::Event.new(channel: "channel").to_h
       expect(connection).to receive(:smembers).with("channel").and_return(["callback1", "callback2"])
-      expect(Toot::CallsEventCallback).to receive(:perform_async).with("callback1", {})
-      expect(Toot::CallsEventCallback).to receive(:perform_async).with("callback2", {})
-      described_class.new.perform("channel", {})
+      expect(Toot::CallsEventCallback).to receive(:perform_async).with("callback1", event_data)
+      expect(Toot::CallsEventCallback).to receive(:perform_async).with("callback2", event_data)
+      described_class.new.perform(event_data)
     end
   end
 end


### PR DESCRIPTION
We now have a way to track data about an event not just the payload.
This includes a UUID and a timestamp that the original event was
generated. This will help with debugging and tracking of events.
